### PR TITLE
Remove erroneous Prelude import

### DIFF
--- a/polysemy-template.hsfiles
+++ b/polysemy-template.hsfiles
@@ -43,7 +43,7 @@ main = defaultMain
 {-# START_FILE src/Main.hs #-}
   {-# LANGUAGE TemplateHaskell #-}
   module Main where
-  import Prelude hiding (throw, catch, bracket)
+
   import Polysemy
   import Polysemy.Input
   import Polysemy.Output


### PR DESCRIPTION
I left that in when writing the README example because I use a custom Prelude. Whoops.